### PR TITLE
feat: add standard 3-job release workflow and update template-init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,28 +4,53 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
+  models: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-          # token: ${{ secrets.GITHUB_TOKEN }}
           token: ${{ github.token }}
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
-          # release-type: simple
 
-          
+  improve-release-notes:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      project_name: "ScooterGitTemplate"
+      # TODO: Replace with a one-sentence description of what this project does
+      project_context: "ScooterGitTemplate is a GitHub repository template providing a standard project scaffold."
+      header: |
+        ## ScooterGitTemplate
 
+        > TODO: Replace with your project tagline.
+
+        ---
+      footer: |
+        ---
+        📖 [User Guide](https://www.scottkirvan.com/ScooterGitTemplate/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=feature_request.md)
+    secrets: inherit
+
+  discord-notify:
+    needs: [release-please, improve-release-notes]
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      project_name: "ScooterGitTemplate"
+      emoji: "🚀"  # TODO: Replace with your project's emoji
+    secrets: inherit

--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -68,6 +68,11 @@ jobs:
           # Process CODE_OF_CONDUCT.md
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" CODE_OF_CONDUCT.md
 
+          # Process release.yml — update project name, repo URLs, and docs URL
+          sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" .github/workflows/release.yml
+          sed -i "s|ScooterGitTemplate|$NEW_NAME|g" .github/workflows/release.yml
+          sed -i "s|https://www.scottkirvan.com/$NEW_NAME/|https://$NEW_OWNER.github.io/$NEW_NAME/|g" .github/workflows/release.yml
+
           echo "Template initialization complete"
 
       - name: Commit changes
@@ -75,7 +80,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md
+          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md .github/workflows/release.yml
           git commit -m "chore: Template initialization complete - updated repository references" || echo "No changes to commit"
           git push
 


### PR DESCRIPTION
## Summary
- Replaces the bare-bones `release-please`-only `release.yml` with the standard 3-job pattern used across all repos:
  - `release-please` — creates release PRs and GitHub releases
  - `improve-release-notes` — AI rewrites the release body via `reusable-release-notes.yml`
  - `discord-notify` — posts the release to Discord via `reusable-discord-notify.yml`
- Adds `workflow_dispatch` trigger and `models: read` permission
- Uses `ScooterGitTemplate` as placeholder strings so `template-init.yml` auto-substitutes them on first push
- Extends `template-init.yml` to also process `.github/workflows/release.yml` (project name, repo URLs, docs URL)

## After creating a repo from this template
`template-init` will auto-replace:
- `ScooterGitTemplate` → repo name (project_name, header)
- `ScottKirvan/ScooterGitTemplate` → full repo path (footer issue links)
- Docs URL → `https://<owner>.github.io/<repo>/`

Still requires manual update:
- `project_context` — one-sentence description of the project
- `emoji` — choose a per-project Discord emoji

## Test plan
- [ ] Create a new repo from this template
- [ ] Verify `template-init` runs and substitutes names correctly in `release.yml`
- [ ] Make a commit and verify release-please creates a chore PR
- [ ] Merge the chore PR and verify all three jobs run