### PR TITLE
fix: add update-changelog-prs job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
         📖 [User Guide](https://www.scottkirvan.com/ScooterGitTemplate/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=feature_request.md)
     secrets: inherit
 
+  update-changelog-prs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-update-changelog-prs.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+
   discord-notify:
     needs: [release-please, improve-release-notes]
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
Adds the `update-changelog-prs` reusable job (from `ScottKirvan/.github`) to the release workflow. After each release it queries GitHub for PRs merged since the previous tag and injects a `### Pull Requests` section into `notes/CHANGELOG.md`.