### PR TITLE
fix: restore template-init and use dynamic repo name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,18 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: "ScooterGitTemplate"
+      project_name: ${{ github.event.repository.name }}
       # TODO: Replace with a one-sentence description of what this project does
-      project_context: "ScooterGitTemplate is a GitHub repository template providing a standard project scaffold."
+      project_context: "${{ github.event.repository.name }} is a project by ${{ github.repository_owner }}."
       header: |
-        ## ScooterGitTemplate
+        ## ${{ github.event.repository.name }}
 
         > TODO: Replace with your project tagline.
 
         ---
       footer: |
         ---
-        📖 [User Guide](https://www.scottkirvan.com/ScooterGitTemplate/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new?template=feature_request.md)
+        📖 [User Guide](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/${{ github.repository }}/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/${{ github.repository }}/issues/new?template=feature_request.md)
     secrets: inherit
 
   update-changelog-prs:
@@ -58,6 +58,6 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: "ScooterGitTemplate"
+      project_name: ${{ github.event.repository.name }}
       emoji: "🚀"  # TODO: Replace with your project's emoji
     secrets: inherit

--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -1,11 +1,8 @@
 name: Template Initialization
 
 # This workflow runs once when a new repository is created from this template.
-# It automatically updates repository references in non-workflow files, then
-# opens a GitHub issue listing the two manual steps that require a token with
-# `workflows` scope (which github.token cannot provide):
-#   1. Update project name/context in .github/workflows/release.yml
-#   2. Delete this file (.github/workflows/template-init.yml)
+# It automatically updates repository references in README, CONTRIBUTING,
+# CODE_OF_CONDUCT, and docs, then deletes itself to keep the repo clean.
 
 on:
   push:
@@ -20,7 +17,6 @@ jobs:
 
     permissions:
       contents: write
-      issues: write
 
     steps:
       - name: Checkout repository
@@ -69,12 +65,8 @@ jobs:
 
           echo "Template initialization complete"
 
-      - name: Commit non-workflow changes
+      - name: Commit changes
         if: steps.check_init.outputs.already_initialized == 'false'
-        env:
-          NEW_NAME: ${{ github.event.repository.name }}
-          NEW_REPO: ${{ github.repository }}
-          NEW_OWNER: ${{ github.repository_owner }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -82,41 +74,9 @@ jobs:
           git commit -m "chore: Template initialization complete - updated repository references" || echo "No changes to commit"
           git push
 
-      - name: Open follow-up issue for manual steps
+      - name: Remove initialization workflow
         if: steps.check_init.outputs.already_initialized == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NEW_NAME: ${{ github.event.repository.name }}
-          NEW_REPO: ${{ github.repository }}
-          NEW_OWNER: ${{ github.repository_owner }}
         run: |
-          gh issue create \
-            --title "chore: Complete template initialization (2 manual steps)" \
-            --body "## Template initialization
-
-          The automated init updated README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, and docs.
-
-          Two steps require a token with \`workflows\` scope and must be done manually:
-
-          ### 1. Update \`.github/workflows/release.yml\`
-
-          Replace all occurrences of \`ScooterGitTemplate\` with \`$NEW_NAME\` and \`ScottKirvan/ScooterGitTemplate\` with \`$NEW_REPO\`:
-
-          \`\`\`
-          project_name: \"$NEW_NAME\"
-          project_context: \"$NEW_NAME is ...\"
-          ## $NEW_NAME
-          \`\`\`
-
-          Also update the docs URL if needed: \`https://$NEW_OWNER.github.io/$NEW_NAME/\`
-
-          ### 2. Delete \`.github/workflows/template-init.yml\`
-
-          This file is no longer needed. Delete it directly on GitHub or via:
-          \`\`\`
           git rm .github/workflows/template-init.yml
-          git commit -m \"chore: remove template-init workflow\"
+          git commit -m "chore: Remove template initialization workflow"
           git push
-          \`\`\`
-
-          Close this issue when both steps are complete."

--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -1,8 +1,11 @@
 name: Template Initialization
 
-# This workflow runs once when a new repository is created from this template
-# It automatically updates all repository references, URLs, and badges in the README
-# After running, it deletes itself to keep the new repository clean
+# This workflow runs once when a new repository is created from this template.
+# It automatically updates repository references in non-workflow files, then
+# opens a GitHub issue listing the two manual steps that require a token with
+# `workflows` scope (which github.token cannot provide):
+#   1. Update project name/context in .github/workflows/release.yml
+#   2. Delete this file (.github/workflows/template-init.yml)
 
 on:
   push:
@@ -17,6 +20,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -42,23 +46,12 @@ jobs:
         run: |
           echo "Initializing template for repository: $NEW_REPO"
 
-          # Use a more robust approach: process the file line by line
-          # This preserves the template credit line while updating everything else
-
           # Process README.md
-          # First pass: Replace full repository path everywhere
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" README.md
-
-          # Second pass: Replace project name, but restore it in the credit line
           sed -i "s|ScooterGitTemplate|$NEW_NAME|g" README.md
-
-          # Third pass: Update deployment URL to use new owner's GitHub Pages
           sed -i "s|https://www.scottkirvan.com/$NEW_NAME/|https://$NEW_OWNER.github.io/$NEW_NAME/|g" README.md
-
-          # Fourth pass: Restore the original template reference in the copyright line
+          # Restore the original template credit line
           sed -i "s|\*\*\[$NEW_NAME\](https://github.com/$NEW_REPO) Copyright|**[ScooterGitTemplate](https://github.com/ScottKirvan/ScooterGitTemplate) Copyright|g" README.md
-
-          # Fifth pass: Restore the license line to reference the original template
           sed -i "s|\*$NEW_NAME is licensed under the \[MIT License\]|\*ScooterGitTemplate is licensed under the [MIT License]|g" README.md
 
           # Process CONTRIBUTING.md
@@ -68,12 +61,7 @@ jobs:
           # Process CODE_OF_CONDUCT.md
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" CODE_OF_CONDUCT.md
 
-          # Process release.yml — update project name, repo URLs, and docs URL
-          sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" .github/workflows/release.yml
-          sed -i "s|ScooterGitTemplate|$NEW_NAME|g" .github/workflows/release.yml
-          sed -i "s|https://www.scottkirvan.com/$NEW_NAME/|https://$NEW_OWNER.github.io/$NEW_NAME/|g" .github/workflows/release.yml
-
-          # Process docs — update project name, repo URLs, base path, and docs URL
+          # Process docs
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" docs/.vitepress/config.mts
           sed -i "s|ScooterGitTemplate|$NEW_NAME|g" docs/.vitepress/config.mts
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" docs/index.md
@@ -81,18 +69,54 @@ jobs:
 
           echo "Template initialization complete"
 
-      - name: Commit changes
+      - name: Commit non-workflow changes
         if: steps.check_init.outputs.already_initialized == 'false'
+        env:
+          NEW_NAME: ${{ github.event.repository.name }}
+          NEW_REPO: ${{ github.repository }}
+          NEW_OWNER: ${{ github.repository_owner }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md .github/workflows/release.yml docs/.vitepress/config.mts docs/index.md
+          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/.vitepress/config.mts docs/index.md
           git commit -m "chore: Template initialization complete - updated repository references" || echo "No changes to commit"
           git push
 
-      - name: Remove initialization workflow
+      - name: Open follow-up issue for manual steps
         if: steps.check_init.outputs.already_initialized == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_NAME: ${{ github.event.repository.name }}
+          NEW_REPO: ${{ github.repository }}
+          NEW_OWNER: ${{ github.repository_owner }}
         run: |
+          gh issue create \
+            --title "chore: Complete template initialization (2 manual steps)" \
+            --body "## Template initialization
+
+          The automated init updated README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, and docs.
+
+          Two steps require a token with \`workflows\` scope and must be done manually:
+
+          ### 1. Update \`.github/workflows/release.yml\`
+
+          Replace all occurrences of \`ScooterGitTemplate\` with \`$NEW_NAME\` and \`ScottKirvan/ScooterGitTemplate\` with \`$NEW_REPO\`:
+
+          \`\`\`
+          project_name: \"$NEW_NAME\"
+          project_context: \"$NEW_NAME is ...\"
+          ## $NEW_NAME
+          \`\`\`
+
+          Also update the docs URL if needed: \`https://$NEW_OWNER.github.io/$NEW_NAME/\`
+
+          ### 2. Delete \`.github/workflows/template-init.yml\`
+
+          This file is no longer needed. Delete it directly on GitHub or via:
+          \`\`\`
           git rm .github/workflows/template-init.yml
-          git commit -m "chore: Remove template initialization workflow"
+          git commit -m \"chore: remove template-init workflow\"
           git push
+          \`\`\`
+
+          Close this issue when both steps are complete."


### PR DESCRIPTION
## What broke and why

Commit `7a05a34` added `.github/workflows/release.yml` to the `git add` in `template-init.yml`. GitHub's `github.token` cannot push changes that create or update workflow files — it lacks the `workflows` OAuth scope. This caused every repo created from the template to fail initialization with:

> `refusing to allow a GitHub App to create or update workflow .github/workflows/release.yml without workflows permission`

The self-delete step was unaffected — GitHub allows *deleting* workflow files with `github.token`.

## Fix

**`release.yml`** — replace hardcoded `"ScooterGitTemplate"` strings with GitHub context variables that resolve correctly at runtime for any repo:
- `project_name: ${{ github.event.repository.name }}`
- `project_context: "${{ github.event.repository.name }} is a project by ${{ github.repository_owner }}."`
- footer links use `${{ github.repository }}` and `${{ github.repository_owner }}`

**`template-init.yml`** — remove all `release.yml` substitutions (sed commands and `git add`). Since `release.yml` no longer has any hardcoded project-specific strings, no substitution is needed. Self-delete step restored unchanged.

## Result

No changes to how users interact with the template. Create repo → init fires automatically → README/CONTRIBUTING/docs substituted → `template-init.yml` self-deletes. Works with zero secrets or manual steps.

## Test plan

- [ ] Create a new repo from this template and verify template-init succeeds
- [ ] Verify `template-init.yml` is deleted from the derived repo
- [ ] Verify a release triggers Discord notification and AI notes with the correct repo name (not "ScooterGitTemplate")