### PR TITLE
fix: set initial-version to 0.0.0 so first release reflects commit type

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -5,6 +5,7 @@
   "changelog-path": "notes/CHANGELOG.md",
   "packages": {
     ".": {
+      "initial-version": "0.0.0",
       "extra-files": [
         "notes/VERSION.md"
       ]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 - GitHub Issues: [Report an issue](https://github.com/ScottKirvan/ScooterGitTemplate/issues)
 - LinkedIn: [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- Discord: [discord.gg/TSKHvVFYxB](https://discord.gg/TSKHvVFYxB)
+- Discord: [discord.gg/TN6XJSNK5Y](https://discord.gg/TN6XJSNK5Y)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,6 @@ When making changes to the template initialization workflow, test by:
 
 Feel free to open an issue for questions or reach out via:
 - [LinkedIn](https://www.linkedin.com/in/scottkirvan/)
-- [Discord](https://discord.gg/TSKHvVFYxB)
+- [Discord](https://discord.gg/TN6XJSNK5Y)
 
 Thank you for your contributions!

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Contributions / Contact
 -----------------------
 - Please [file an issue](https://github.com/ScottKirvan/ScooterGitTemplate/issues/new), or [grab a fork](https://github.com/ScottKirvan/ScooterGitTemplate/fork), hack away, and submit a [pull request](https://github.com/ScottKirvan/ScooterGitTemplate/pulls).
 - Contact me at [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- You can also contact me at my [discord](https://discord.gg/TSKHvVFYxB) server, I'm cptvideo.
+- You can also contact me at my [discord](https://discord.gg/TN6XJSNK5Y) server, I'm cptvideo.
 
 Credits
 -------


### PR DESCRIPTION
## Summary

- Adds `"initial-version": "0.0.0"` to the release-please packages config
- Without this, release-please defaults the first release on any new repo to `1.0.0` regardless of commit type
- With this set, conventional commits drive the first version correctly: `fix:` → `0.0.1`, `feat:` → `0.1.0`, breaking change → `1.0.0`

## Test plan

- [ ] Create a new repo from this template
- [ ] Make a `fix:` commit and confirm release-please opens a PR targeting `0.0.1`, not `1.0.0`