### PR TITLE
feat: add pre-release staging workflow, update release pipeline

### DIFF
--- a/.github/workflows/pre-release-staging.yml
+++ b/.github/workflows/pre-release-staging.yml
@@ -1,0 +1,34 @@
+name: Manual — Pre-Release Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Version tag override — leave blank to infer from open release-please PR
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  models: read
+  pull-requests: read
+
+jobs:
+  stage:
+    uses: ScottKirvan/.github/.github/workflows/reusable-pre-release-staging.yml@main
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      project_name: ${{ github.event.repository.name }}
+      # TODO: Replace with a one-sentence description of what this project does
+      project_context: "${{ github.event.repository.name }} is a project by ${{ github.repository_owner }}."
+      header: |
+        ## ${{ github.event.repository.name }}
+
+        > TODO: Replace with your project tagline.
+
+        ---
+      footer: |
+        ---
+        📖 [User Guide](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/${{ github.repository }}/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/${{ github.repository }}/issues/new?template=feature_request.md)
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,54 @@ jobs:
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
 
-  improve-release-notes:
+  apply-staged-notes:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    outputs:
+      used_staging: ${{ steps.apply.outputs.used_staging }}
+      discord_blurb: ${{ steps.apply.outputs.discord_blurb }}
+    steps:
+      - name: Apply staged notes and clean up
+        id: apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          STAGING_BRANCH="pre-release-staging/$TAG"
+
+          if ! gh api "repos/$REPO/branches/$STAGING_BRANCH" > /dev/null 2>&1; then
+            echo "used_staging=false" >> "$GITHUB_OUTPUT"
+            echo "No staging branch found for $TAG — will fall back to AI generation"
+            exit 0
+          fi
+
+          echo "Found staging branch: $STAGING_BRANCH"
+
+          NOTES=$(gh api "repos/$REPO/contents/.github/tmp/pre-release-staging/release-notes.md?ref=$STAGING_BRANCH" \
+            --jq '.content' | base64 -d)
+          BLURB=$(gh api "repos/$REPO/contents/.github/tmp/pre-release-staging/discord-blurb.txt?ref=$STAGING_BRANCH" \
+            --jq '.content' | base64 -d 2>/dev/null || echo "")
+
+          printf '%s' "$NOTES" > /tmp/staged-release-notes.md
+          gh release edit "$TAG" --repo "$REPO" --notes-file /tmp/staged-release-notes.md
+          echo "Applied staged release notes to $TAG"
+
+          gh api "repos/$REPO/git/refs/heads/$STAGING_BRANCH" --method DELETE || true
+          echo "Deleted staging branch: $STAGING_BRANCH"
+
+          echo "used_staging=true" >> "$GITHUB_OUTPUT"
+          { echo 'discord_blurb<<BLURB_EOF'
+            printf '%s\n' "$BLURB"
+            echo 'BLURB_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  improve-release-notes:
+    needs: [release-please, apply-staged-notes]
+    if: >-
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.apply-staged-notes.outputs.used_staging == 'false'
     uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
@@ -53,11 +98,15 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   discord-notify:
-    needs: [release-please, improve-release-notes]
-    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please, apply-staged-notes, improve-release-notes]
+    if: >-
+      always() &&
+      needs.release-please.outputs.release_created == 'true' &&
+      !failure() && !cancelled()
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: ${{ github.event.repository.name }}
       emoji: "🚀"  # TODO: Replace with your project's emoji
+      discord_blurb: ${{ needs.apply-staged-notes.outputs.discord_blurb || needs.improve-release-notes.outputs.discord_blurb }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `pre-release-staging.yml` — run this manually before a release to generate AI notes, save the full assembled body (header + notes + footer) to a staging branch, and create/update a draft GitHub release for review and editing
- Updates `release.yml` (or `release-please.yml`) with a new `apply-staged-notes` job: checks for a `pre-release-staging/{tag}` branch via API exit code (avoids the `gh api --jq` null-on-404 false-positive bug), reads notes and discord blurb via API, applies them to the release, and deletes the staging branch
- `improve-release-notes` is now conditional on `used_staging == 'false'` — it only runs when no staging branch was found
- `discord-notify` now uses `always() && !failure() && !cancelled()` and passes the blurb from whichever path ran
- Also fixes missing \`discord_blurb\` passthrough that was previously absent from discord-notify
- Removes `preview-release-notes.yml` — superseded by the new staging workflow

## Test plan

- [ ] Merge this PR
- [ ] Run `Manual — Pre-Release Staging` in Actions (leave tag blank to auto-infer from open release-please PR)
- [ ] Check the staging branch and draft release; edit if needed
- [ ] Trigger a release and confirm staged notes are applied and the staging branch is deleted
- [ ] Confirm fallback AI generation works on a release with no staging branch