### PR TITLE
fix: migrate starline badge to self-hosted GitHub Action

### DIFF
--- a/.github/workflows/update-starline.yml
+++ b/.github/workflows/update-starline.yml
@@ -1,0 +1,39 @@
+name: Update Starline
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # weekly on Sunday at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  starline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Switch to or create starlines branch
+        shell: bash
+        run: |
+          if git ls-remote --exit-code origin refs/heads/starlines > /dev/null 2>&1; then
+            git checkout starlines
+          else
+            git checkout --orphan starlines
+            git rm -rf . > /dev/null 2>&1 || true
+          fi
+
+      - uses: qoomon/starlines@main
+        with:
+          output-directory: ./
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: update starline" || true
+          git push origin starlines

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ScooterGitTemplate [![starline](https://starlines.qoo.monster/assets/ScottKirvan/ScooterGitTemplate)](https://github.com/qoomon/starline)
+﻿# ScooterGitTemplate [![starline](https://raw.githubusercontent.com/ScottKirvan/ScooterGitTemplate/refs/heads/starlines/ScottKirvan/ScooterGitTemplate/starline.svg)](https://github.com/qoomon/starlines)
 <div align="center">
 
   <img src="assets/media/logo.jpg" alt="logo" width="200" height="auto" />


### PR DESCRIPTION
## Summary

- Replaces broken `starlines.qoo.monster` badge (GitHub API restricted stargazer access June 30, 2026)
- Adds `update-starline.yml` workflow: runs weekly + on-demand, generates SVG via `qoomon/starlines@main`, commits to orphan `starlines` branch in this repo
- Updates README badge URL to point at the self-hosted SVG

## Test plan

- [ ] Run `Update Starline` workflow dispatch manually after merge to generate the initial SVG
- [ ] Verify the badge renders in the README