### PR TITLE
feat: add CLAUDE.md with project conventions

### DIFF
--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -63,6 +63,9 @@ jobs:
           sed -i "s|ScottKirvan/ScooterGitTemplate|$NEW_REPO|g" docs/index.md
           sed -i "s|ScooterGitTemplate|$NEW_NAME|g" docs/index.md
 
+          # Process CLAUDE.md — replace only the title; preserve the template credit link
+          sed -i "s|# CLAUDE.md — ScooterGitTemplate|# CLAUDE.md — $NEW_NAME|g" CLAUDE.md
+
           echo "Template initialization complete"
 
       - name: Commit changes
@@ -70,7 +73,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/.vitepress/config.mts docs/index.md
+          git add README.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/.vitepress/config.mts docs/index.md CLAUDE.md
           git commit -m "chore: Template initialization complete - updated repository references" || echo "No changes to commit"
           git push
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,14 @@
 # CLAUDE.md — ScooterGitTemplate
 
+## Keeping This File Current
+
+This file is the primary context for any agent working in this repo — keep it accurate
+as the project evolves. When you learn what the project is, add a brief description at
+the top. As key files, build commands, and architectural decisions emerge, record them
+here so future sessions start with full context rather than re-deriving it.
+
+Update this file in the same commit as the work it documents.
+
 ## Working Conventions
 
 - Never commit or push directly to `main`. Always branch first, then PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,17 +12,19 @@
   use `fix:`, even when they close a tracked issue.
 - Unit tests must be written alongside all new code. All bug fixes require red/green
   tests — a failing test that reproduces the bug, then the fix that makes it pass.
-- CI, lint, and formatting must all pass before committing or opening a PR.
+- CI, lint, and formatting must all pass before committing or opening a PR. Discover
+  the project's commands from the CI config, `package.json`, `Makefile`, or equivalent
+  — do not assume they match another project's toolchain.
 
 ## No Shortcuts
 
-Nothing is deferred without explicit permission from the project owner. A known issue
-is still a bug — do not mark it "won't fix", "by design", or "out of scope" unilaterally.
+Nothing is deferred without explicit permission from the user. A known issue is still
+a bug — do not mark it "won't fix", "by design", or "out of scope" unilaterally.
 
-If a library or package cannot meet a requirement in the spec, the answer is to find
-an alternative or do the work from first principles — not to defer the requirement or
-revise the spec to fit the limitation. The spec defines what the project needs; the
-implementation serves the spec, not the other way around.
+If a library or package cannot meet the stated requirements, the answer is to find an
+alternative or do the work from first principles — not to defer the requirement or
+revise it to fit the limitation. The requirements define what the project needs; the
+implementation serves the requirements, not the other way around.
 
 ## Attribution
 
@@ -37,7 +39,8 @@ can inject attribution without the agent's knowledge. Before finalizing any comm
 
 ## GitHub Issues and PRs
 
-Issue and PR templates live in `ScottKirvan/.github` and apply to this repo automatically.
+Issue and PR templates live in `ScottKirvan/.github` (or your org's equivalent) and
+apply to this repo automatically via GitHub's community health file fallback.
 
 - Bug reports → `[BUG]` title prefix, `bug_report.md` sections
 - Feature requests → `[FEATURE]` title prefix, `feature_request.md` sections
@@ -54,9 +57,10 @@ When using sub-agents for implementation:
 - Brief sub-agents on **what** to build, not **how** — implementation decisions belong
   to the sub-agent, which serves as an independent second opinion on the approach.
 - Sub-agents follow all conventions in this file except they do not create PRs.
-- The launching agent reviews the sub-agent's diff and tests before creating the PR.
+- After a sub-agent completes, review its diff and tests before creating the PR.
   This review is a genuine code review, not a compliance check — evaluate correctness,
-  spec alignment, and test quality independently.
-- Simple issues found in review may be fixed directly. Significant deviations from spec
-  or complex problems go back to the sub-agent rather than being patched over.
-- The launching agent creates the PR only after review passes.
+  requirement alignment, and test quality independently.
+- Simple issues found in review may be fixed directly. Significant deviations from the
+  stated requirements or complex problems go back to the sub-agent rather than being
+  patched over.
+- Create the PR only after review passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — ScooterGitTemplate
+
+## Current Status
+Just created from the [ScooterGitTemplate](https://github.com/ScottKirvan/ScooterGitTemplate).
+README and other files contain placeholder lorem ipsum — complete the customization
+checklist in README.md before starting any other work.
+
+## Working Conventions
+
+- Never commit or push directly to `main`. Always branch first, then PR.
+- Branch names must describe the work (e.g. `fix/login-timeout`, `feat/export-csv`).
+- Rebase and merge PRs. After merge: `git checkout main && git pull`, delete the branch.
+- Conventional commits: `feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:`.
+  Breaking: `feat!:`.
+- `feat:` is for genuinely new user-facing capabilities only. Bug fixes and corrections
+  use `fix:`, even when they close a tracked issue.
+
+## Attribution
+
+No attribution of any kind in commit messages, PR bodies, or issue text — no
+"Generated with", "Co-Authored-By", "Created by Claude", or any AI/tool credit lines.
+
+**Verify by reading the repo, not from memory.** Tooling (GitHub Actions, IDE plugins)
+can inject attribution without the agent's knowledge. Before finalizing any commit or PR:
+- Run `git log` and read the actual commit messages
+- Read the actual PR body text
+- Remove any attribution found, regardless of source
+
+## GitHub Issues and PRs
+
+Issue and PR templates live in `ScottKirvan/.github` and apply to this repo automatically.
+
+- Bug reports → `[BUG]` title prefix, `bug_report.md` sections
+- Feature requests → `[FEATURE]` title prefix, `feature_request.md` sections
+- General → `[GENERAL]` title prefix, `general_report.md` sections
+- PRs → fill all checklist sections; no attribution anywhere in the body
+
+Before creating any issue: check for duplicates first (`gh issue list --state open --limit 100`).
+Create issues only when explicitly asked — don't preemptively file future work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,28 @@
 # CLAUDE.md — ScooterGitTemplate
 
-## Current Status
-Just created from the [ScooterGitTemplate](https://github.com/ScottKirvan/ScooterGitTemplate).
-README and other files contain placeholder lorem ipsum — complete the customization
-checklist in README.md before starting any other work.
-
 ## Working Conventions
 
 - Never commit or push directly to `main`. Always branch first, then PR.
 - Branch names must describe the work (e.g. `fix/login-timeout`, `feat/export-csv`).
-- Rebase and merge PRs. After merge: `git checkout main && git pull`, delete the branch.
+  No random characters, UUIDs, or generated suffixes to ensure uniqueness — if a name
+  is already taken, pick a more specific descriptive name instead.
 - Conventional commits: `feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:`.
   Breaking: `feat!:`.
 - `feat:` is for genuinely new user-facing capabilities only. Bug fixes and corrections
   use `fix:`, even when they close a tracked issue.
+- Unit tests must be written alongside all new code. All bug fixes require red/green
+  tests — a failing test that reproduces the bug, then the fix that makes it pass.
+- CI, lint, and formatting must all pass before committing or opening a PR.
+
+## No Shortcuts
+
+Nothing is deferred without explicit permission from the project owner. A known issue
+is still a bug — do not mark it "won't fix", "by design", or "out of scope" unilaterally.
+
+If a library or package cannot meet a requirement in the spec, the answer is to find
+an alternative or do the work from first principles — not to defer the requirement or
+revise the spec to fit the limitation. The spec defines what the project needs; the
+implementation serves the spec, not the other way around.
 
 ## Attribution
 
@@ -37,3 +46,17 @@ Issue and PR templates live in `ScottKirvan/.github` and apply to this repo auto
 
 Before creating any issue: check for duplicates first (`gh issue list --state open --limit 100`).
 Create issues only when explicitly asked — don't preemptively file future work.
+
+## Sub-Agent Workflow
+
+When using sub-agents for implementation:
+
+- Brief sub-agents on **what** to build, not **how** — implementation decisions belong
+  to the sub-agent, which serves as an independent second opinion on the approach.
+- Sub-agents follow all conventions in this file except they do not create PRs.
+- The launching agent reviews the sub-agent's diff and tests before creating the PR.
+  This review is a genuine code review, not a compliance check — evaluate correctness,
+  spec alignment, and test quality independently.
+- Simple issues found in review may be fixed directly. Significant deviations from spec
+  or complex problems go back to the sub-agent rather than being patched over.
+- The launching agent creates the PR only after review passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@
 - Branch names must describe the work (e.g. `fix/login-timeout`, `feat/export-csv`).
   No random characters, UUIDs, or generated suffixes to ensure uniqueness — if a name
   is already taken, pick a more specific descriptive name instead.
+- One concern per branch and PR. If work naturally splits into independent problems,
+  split the branches too — resist bundling unrelated changes into one PR.
 - Conventional commits: `feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:`.
   Breaking: `feat!:`.
 - `feat:` is for genuinely new user-facing capabilities only. Bug fixes and corrections
@@ -15,6 +17,14 @@
 - CI, lint, and formatting must all pass before committing or opening a PR. Discover
   the project's commands from the CI config, `package.json`, `Makefile`, or equivalent
   — do not assume they match another project's toolchain.
+- Prefer narrow, localised changes. Favour modularity that contains the blast radius
+  of future edits — a fix or feature should not require touching unrelated parts of
+  the codebase. If it does, that's a design signal worth surfacing.
+- Refactoring is a first-class activity, not something to defer. Improve structure as
+  you go rather than accumulating technical debt for a later pass.
+- When working in unfamiliar domain territory, prefer primary sources — official docs,
+  specs, RFCs — over general knowledge. Flag domain uncertainty explicitly rather than
+  proceeding on an assumption.
 
 ## No Shortcuts
 
@@ -25,6 +35,12 @@ If a library or package cannot meet the stated requirements, the answer is to fi
 alternative or do the work from first principles — not to defer the requirement or
 revise it to fit the limitation. The requirements define what the project needs; the
 implementation serves the requirements, not the other way around.
+
+## Autonomy
+
+Make implementation decisions independently — don't ask permission for technical
+choices within the stated requirements. Escalate only when something would change
+scope, defer a requirement, or contradict what the user has described as the goal.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 > - [ ] Fill in the Features, Installation, and Usage sections below
 > - [ ] Review and update the [Code of Conduct](CODE_OF_CONDUCT.md) contact information
 > - [ ] Enable GitHub Pages in repository settings if you want a project website
+> - [ ] Review and customize `CLAUDE.md` if using AI coding agents, or delete it if not
 > - [ ] Remove or update this checklist section
 
 Branches
@@ -81,6 +82,7 @@ ScooterGitTemplate
 │   ├───css                      # Styling for GitHub Pages
 │   └───media                    # Images and logos
 ├───notes                        # CHANGELOG, VERSION, TODO
+├───CLAUDE.md                    # AI agent context (optional — see Key Features)
 ├───CODE_OF_CONDUCT.md           # Community guidelines
 ├───CONTRIBUTING.md              # Contribution guidelines
 ├───LICENSE.md                   # MIT License
@@ -96,6 +98,8 @@ ScooterGitTemplate
 **Template Initialization**: The `template-init.yml` workflow automatically updates repository references when you create a new repo from this template, then deletes itself.
 
 **.gitignore Templates**: The `.github/gitignore-templates/` folder contains ready-to-use `.gitignore` files for Unreal Engine, Unity, Python, Node.js, C++, and general development. See the [templates README](.github/gitignore-templates/) for usage.
+
+**AI Agent Context (optional)**: `CLAUDE.md` gives AI coding agents (e.g. [Claude Code](https://claude.ai/code)) a starting set of engineering standards — branching conventions, commit discipline, test-driven development, and a no-shortcuts ethos. The project name is automatically substituted on initialization. Customize it as your project evolves, or delete it if you're not using AI agents.
 
 >[!NOTE]
 > When using this template project, do not clone the tags or branches. Stick with `main` as the name of your main release branch. Change the version number in the `.release-please-manifest.json` file to the version you want to start with.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to the template root with branching, commit, attribution, and issue/PR conventions pre-filled
- Updates `template-init.yml` to substitute the project name in the `CLAUDE.md` title on first push; the template credit link in the body is preserved unchanged

## Test plan

- [ ] Create a new repo from this template and push a commit to trigger `template-init`
- [ ] Confirm `CLAUDE.md` title reads `# CLAUDE.md — <new-repo-name>` after the workflow runs
- [ ] Confirm the `ScooterGitTemplate` link in the Current Status section is unchanged