### PR TITLE
fix: clean up issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ If applicable, add screenshots to help explain your problem.
 ## Environment
 - OS: [e.g. Windows 11, macOS 14, Ubuntu 22.04]
 - Version: [e.g. 1.2.3]
-- Unreal Engine Version: [if applicable, e.g. UE 5.3]
+- Relevant toolchain/framework versions: [e.g. Node 20, Flutter 3.x, UE 5.3]
 - Additional context: [any other relevant information]
 
 ## Additional Context

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,8 +1,23 @@
 ---
 name: Documentation Issue
-about: Create a report to help us improve
+about: Report missing, incorrect, or unclear documentation
 title: '[DOCS] '
 labels: documentation
 assignees: ''
 
 ---
+
+## Description
+A clear and concise description of the documentation problem.
+
+## Location
+Where is the documentation that needs attention? (file path, URL, section heading)
+
+## What's Wrong or Missing
+Describe what is incorrect, unclear, or absent.
+
+## Expected Outcome
+What should the documentation say or cover?
+
+## Additional Context
+Add any other context, screenshots, or examples here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,20 +15,29 @@ Please delete options that are not relevant.
 - [ ] Other (please describe):
 
 ## How Has This Been Tested?
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
+Describe the automated tests added or run to verify these changes.
 
-- [ ] Test A
-- [ ] Test B
+- [ ] Unit tests added / updated
+- [ ] Existing tests pass
 
 **Test Configuration**:
 - OS:
 - Version:
-- Unreal Engine Version (if applicable):
+- Relevant toolchain/framework versions:
+
+## User Testing / Acceptance
+Step-by-step instructions for verifying this change works correctly from the user's perspective. Be specific enough that someone unfamiliar with the change can follow without guessing.
+
+1. 
+2. 
+3. 
+
+**Expected outcome:**
 
 ## Checklist
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] Comments are present only where the *why* is non-obvious — well-named code should be self-documenting
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
## Summary

- Removed stale Unreal Engine-specific field from `bug_report.md` and `PULL_REQUEST_TEMPLATE.md` — replaced with generic "Relevant toolchain/framework versions"
- Added **User Testing / Acceptance** section to PR template with step-by-step instructions prompt and expected outcome field
- Replaced "I have commented my code" checklist item with a statement of the actual convention: comments only where the *why* is non-obvious
- Filled in the empty `documentation.md` issue template with Description, Location, What's Wrong or Missing, Expected Outcome, and Additional Context sections

## User Testing / Acceptance

1. Open a new PR in any repo using this template — confirm the PR body renders the User Testing section and updated checklist
2. File a new bug report — confirm "Relevant toolchain/framework versions" appears instead of the Unreal-specific field
3. File a new documentation issue — confirm sections are present