### PR TITLE
docs: close two gaps in branch-naming and attribution rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ Update this file in the same commit as the work it documents.
 - Branch names must describe the work (e.g. `fix/login-timeout`, `feat/export-csv`).
   No random characters, UUIDs, or generated suffixes to ensure uniqueness — if a name
   is already taken, pick a more specific descriptive name instead.
+- If a branch name is pre-assigned by tooling (a hosted agent session, a CI runner)
+  rather than chosen by you, verify it against this convention before the first push.
+  Rename locally (`git branch -m <name>`) if it doesn't match — being handed a name
+  isn't an exemption from the rule.
 - One concern per branch and PR. If work naturally splits into independent problems,
   split the branches too — resist bundling unrelated changes into one PR.
 - Conventional commits: `feat:` / `fix:` / `docs:` / `chore:` / `refactor:` / `test:`.
@@ -65,11 +69,16 @@ scope, defer a requirement, or contradict what the user has described as the goa
 No attribution of any kind in commit messages, PR bodies, or issue text — no
 "Generated with", "Co-Authored-By", "Created by Claude", or any AI/tool credit lines.
 
-**Verify by reading the repo, not from memory.** Tooling (GitHub Actions, IDE plugins)
-can inject attribution without the agent's knowledge. Before finalizing any commit or PR:
+**Verify by reading the repo, not from memory.** Some git hosting integrations inject
+a footer server-side even into a request that omitted one — treat that as expected
+behavior, not a surprise. After every commit and after every PR create/update, re-read
+the actual result and strip any attribution found, regardless of source:
 - Run `git log` and read the actual commit messages
-- Read the actual PR body text
+- Re-fetch and read the actual PR body text
 - Remove any attribution found, regardless of source
+
+A commit or PR is not finished until this read-back check has run — don't rely on what
+you wrote, check what actually landed.
 
 ## GitHub Issues and PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,12 @@ implementation serves the requirements, not the other way around.
 ## Communication
 
 Ask questions in natural language. Never use a multiple choice / structured question
-tool — if clarification is needed, just ask directly in plain text.
+tool — including Claude Code's `AskUserQuestion` tool — if clarification is needed,
+just ask directly in plain text. This is a project-wide preference, not a
+per-session one: some interfaces render binned/multiple-choice questions poorly,
+and forcing a question into fixed options loses the nuance an open question
+would surface. Standard engineering practice is to ask a real question and read
+a real answer, not to pick from a menu.
 
 ## Autonomy
 
@@ -90,7 +95,11 @@ apply to this repo automatically via GitHub's community health file fallback.
 - General → `[GENERAL]` title prefix, `general_report.md` sections
 - PRs → fill all checklist sections; no attribution anywhere in the body
 
-Before creating any issue: check for duplicates first (`gh issue list --state open --limit 100`).
+Before creating any issue: check for duplicates first — `gh issue list --state open
+--limit 100` where the `gh` CLI is available, or the equivalent GitHub search/list
+tool (e.g. an MCP GitHub server's `search_issues`/`list_issues`) in hosted sessions
+that don't have `gh`. Don't skip the check just because the literal command doesn't
+apply in a given environment.
 Create issues only when explicitly asked — don't preemptively file future work.
 
 ## Sub-Agent Workflow


### PR DESCRIPTION
## Description
Four small fixes to rules that already existed in this file but got broken in practice during a real session. The common thread: rules were framed as things the agent originates, not as checks against defaults tooling hands it, or against tools/commands that don't exist in every environment.

1. **Branch naming** — a hosted agent session pre-assigned a branch name with a random generated suffix (e.g. `claude/project-onboarding-setup-qs2zwk`). The existing "no random suffixes" rule wasn't checked against it because the agent didn't choose that name itself. Added a bullet under Working Conventions: verify a pre-assigned branch name against the convention before the first push, and rename locally if it doesn't match.

2. **Attribution** — the agent's own PR-creation request correctly omitted an attribution footer, but the GitHub integration used to post it injected one server-side anyway. The existing "verify by reading the repo" guidance was there but read as passive awareness rather than a required action tied to a specific moment. Reworded it as an explicit gate: after every commit and PR create/update, re-read the actual result and strip any attribution found — a commit or PR isn't finished until that read-back has happened.

3. **Communication** — the "never use a structured question tool" rule didn't name Claude Code's `AskUserQuestion` tool specifically, so an agent unfamiliar with that tool's name could reach for it anyway. Named it explicitly and stated this is a project-wide preference, not a stylistic default: some interfaces render binned/multiple-choice questions poorly, and forcing a real question into fixed options loses nuance that engineering questions need.

4. **Issue duplicate-check** — the rule's example command (`gh issue list ...`) assumes the `gh` CLI is on PATH, which isn't true in hosted/remote sessions that only have GitHub MCP tools. Reworded so the *check* is the requirement, satisfiable via `gh` or an equivalent search/list tool, rather than something a literal command mismatch lets an agent skip.

No other sections changed.

## Type of Change
- [x] Documentation update